### PR TITLE
Update scheduler.conf

### DIFF
--- a/config/etc/supervisor/conf.d-temp/scheduler.conf
+++ b/config/etc/supervisor/conf.d-temp/scheduler.conf
@@ -1,6 +1,6 @@
 # Command scheduler
 [program:laravel-scheduler]
-command=sh -c "while [ true ]; do (cd /var/www/app && php artisan schedule:run >> /dev/null 2>&1); sleep 1; done"
+command=sh -c "while [ true ]; do (cd /var/www/app && php artisan schedule:run >> /dev/null 2>&1); sleep 60; done"
 redirect_stderr=true
 autostart=true
 autorestart=true


### PR DESCRIPTION
Rollback default scheduler to 60 seconds. If needed to use sub-minute tasks you should override this `schedule.conf` on your app.